### PR TITLE
fix typo in footer text

### DIFF
--- a/website/utils/footer.php
+++ b/website/utils/footer.php
@@ -16,7 +16,7 @@ LE COSTANTI FACEBOOK E LINKEDIN SONO STATE DEFINITE NELL' HEADER TOP BAR
                     SANER follows the highly successful <a style="cursor: pointer;">IEEE CSMR-WCRE</a> Software Evolution Week, which was held in Antwerp, Belgium, 2014.
                 </p>
                 <p>
-                    Web Design by <a href="https://github.com/aparzi/saner2018" target="_blank">Angelo Parziale</a> (University of Moline)
+                    Web Design by <a href="https://github.com/aparzi/saner2018" target="_blank">Angelo Parziale</a> (<a href="https://www.unimol.it/" target="_blank">University of Molise</a>)
                 </p>
             </div>
 


### PR DESCRIPTION
Hi, I am a Ph.D. student at the University of Molise.
I noticed a small typo in the SANER website footer.
This pull request provides a possible fix, that is "Università delle Moline" -> "Università del Molise".
You can check this information by visiting the personal website of the web designer (Partial Angel), as reported in his GitHub profile.
He was also a student at my university.

Thanks in advance,
Giovanni Rosa